### PR TITLE
Add GitHub Actions workflows for building and testing PHP extensions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,52 @@
+name: build-release.yml
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: none
+          tools: phpize
+
+      - name: Build extension
+        run: |
+          phpize
+          ./configure --enable-keccak256
+          make
+          mkdir -p build
+          cp modules/keccak256.so build/keccak256-${{ matrix.php }}.so
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: so-${{ matrix.php }}
+          path: build/*.so
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./dist
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*.so
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  workflow_call:
+
+jobs:
+  ci:
+    name: Feature & Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ 8.0, 8.1, 8.2, 8.3, 8.4 ]
+
+    steps:
+      # Checkout Code (current branch)
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Install PHP
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: none
+          tools: phpize
+
+      - name: Build extension
+        run: |
+          phpize
+          ./configure --enable-keccak256
+          make
+          mkdir -p build
+
+      - name: Run Tests
+        run: |
+          php -d extension=./modules/keccak256-${{ matrix.php }}.so tests/run_comprehensive_tests.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php }}
-          extensions: none
+          extensions: ctype
           tools: phpize
 
       - name: Build extension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          php -d extension=./modules/keccak256-${{ matrix.php }}.so tests/run_comprehensive_tests.php
+          php -d extension=./modules/keccak256.so tests/run_comprehensive_tests.php

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,12 @@
+name: Pull Request
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Continuous Integration
+    uses: ./.github/workflows/ci.yml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern PHP extension providing the `keccak256()` function for Ethereum develop
 
 ## Features
 
-- **Modern PHP Support**: Compatible with PHP 8.0, 8.1, 8.2, and 8.3
+- **Modern PHP Support**: Compatible with PHP 8.0, 8.1, 8.2, 8.3, and 8.4
 - **High Performance**: Native C implementation for optimal speed
 - **Proper Error Handling**: Comprehensive input validation with descriptive error messages
 - **Memory Safe**: Uses PHP's memory management system to prevent leaks


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows to automate building, testing, and releasing the PHP extension. The main changes are the addition of workflows for continuous integration (CI), pull request validation, and automated release builds covering multiple PHP versions.

**CI and Testing Automation:**
* Added `.github/workflows/ci.yml` to run feature and unit tests across PHP versions 8.0–8.4 using matrix builds. This workflow sets up PHP, builds the extension, and runs comprehensive tests.
* Introduced `.github/workflows/pull-request.yml` to automatically trigger the CI workflow for every pull request, ensuring code quality before merging.

**Release Automation:**
* Added `.github/workflows/build-release.yml` to automate building the extension for multiple PHP versions on release or manual dispatch. Artifacts are uploaded and attached to the GitHub release.