### PR TITLE
Add PHP 8.5 Support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         arch: [x86_64, aarch64]
         include:
           - arch: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Feature & Unit Tests
     strategy:
       matrix:
-        php: [ 8.0, 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 ]
         arch: [x86_64, aarch64]
         include:
           # from 


### PR DESCRIPTION
## Summary

This PR adds PHP 8.5 compatibility to the Keccak256PHP extension by updating the CI/CD workflows to include PHP 8.5 in the test matrix and build process.

---

## Changes

#### 1. CI Workflow Updates

- **Updated:**
  - `.github/workflows/ci.yml`: Added PHP 8.5 to the test matrix (line 10) to enable automated testing for PHP 8.5 across both x86_64 and aarch64 architectures.

#### 2. Build & Release Workflow Updates

- **Updated:**
  - `.github/workflows/build-release.yml`: Added PHP 8.5 to the build matrix (line 11) to ensure the extension is compiled and released for PHP 8.5 on both x86_64 and aarch64 architectures.

---

## Impact

- The extension will now be tested against PHP 8.5 in CI
- Release artifacts will include PHP 8.5 binaries for both architectures
- Maintains backward compatibility with PHP 8.0-8.4