### PR TITLE
ci: add SonarQube analysis and actionlint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Main
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  ci:
+    name: Continuous Integration
+    uses: ./.github/workflows/ci.yml
+
+  sonar:
+    needs: ci
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history for SCM blame
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,22 +23,3 @@ jobs:
   ci:
     name: Continuous Integration
     uses: ./.github/workflows/ci.yml
-
-  # Temporary: run the SonarQube scan on PRs to validate it before relying on
-  # main.yml. Gated to same-repo PRs so fork PRs never run with secrets.
-  sonar:
-    name: SonarQube Analysis
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0 # full history for SCM blame
-
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
   ci:
     name: Continuous Integration
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,3 +23,22 @@ jobs:
   ci:
     name: Continuous Integration
     uses: ./.github/workflows/ci.yml
+
+  # Temporary: run the SonarQube scan on PRs to validate it before relying on
+  # main.yml. Gated to same-repo PRs so fork PRs never run with secrets.
+  sonar:
+    name: SonarQube Analysis
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history for SCM blame
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=Accredifysg_Keccak256PHP
+sonar.projectName=Keccak256PHP
+
+# sources
+# This repo's product is a native C extension, which SonarQube Community
+# Edition cannot analyze. Point analysis at the PHP test scripts instead.
+sonar.sources=tests


### PR DESCRIPTION
## Summary

Mirrors the SonarQube + workflow-linting setup from [PHP-JSON-LD#8](https://github.com/Accredifysg/PHP-JSON-LD/pull/8), adapted to this native C-extension repo. Because this project builds via `phpize`/`make` and has no Composer/Pest/PHPStan, the PR's coverage layer (pcov, clover/junit artifacts, `workflow_call` outputs) does not apply and was intentionally omitted.

---

## CI/CD Enhancements

#### 1. Push Workflow

- **Added:**
  - `.github/workflows/main.yml`: On push to `master`, runs the reusable `ci` workflow, then a `sonar` job that checks out (full history for SCM blame) and runs `SonarSource/sonarqube-scan-action@v8.2.0` against `SONAR_HOST_URL` + `SONAR_TOKEN`.

#### 2. Pull Request Workflow

- **Updated:**
  - `.github/workflows/pull-request.yml`: Adds an `actionlint` job that downloads actionlint via the official script and lints all workflow files, alongside the existing `ci` job.

#### 3. SonarQube Config

- **Added:**
  - `sonar-project.properties`: Project key `Accredifysg_Keccak256PHP`. SonarQube Community Edition cannot analyze C/C++, so `sonar.sources` targets the PHP test scripts (`tests`).

---

## Deliberate divergences from the source PR

- Targets `master` (this repo's default branch) instead of `main`.
- No coverage / artifact plumbing — no Pest/Composer to produce it.
- `sonar.sources=tests` (no `sonar.tests`, which would conflict).
- `actions/checkout@v5` to match this repo's existing convention.

## Notes

- Requires `SONAR_TOKEN` and `SONAR_HOST_URL` repo secrets (not yet configured).
- Validated locally with `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
